### PR TITLE
return type yes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 declare module 'swallowify' {
-	function swallowify(eventfulFunction: Function): any;
+  type EventfulFunction<A> = (event: Event) => A
+	function swallowify<A>(eventfulFunction: EventfulFunction<A>): EventfulFunction<A>;
 	export = swallowify;
 }


### PR DESCRIPTION
`typeof fn === 'function'` returns `false` - ts no need silly check

```
function onClick1(e: Event) {}
function onClick2(e: number) {}
function onClick3(e1: Event, e2: Event) {}

swallowify(onClick1) // works
swallowify(onClick2) // no works
swallowify(onClick3) // no works
```

